### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -4,7 +4,7 @@
    ],
    "depends" : [],
    "description" : "Perl6 modules for handling protocol status as Exceptions",
-   "license" : "http://www.perlfoundation.org/artistic_license_2_0",
+   "license" : "Artistic-2.0",
    "name" : "X::Protocol",
    "perl" : "6",
    "provides" : {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license